### PR TITLE
Update thrift version to 0.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.10.2" %}  # PEP 386
 {% set source_version = version %}
 {% set base_version = version %}
-{% set number = "4" %}
+{% set number = "5" %}
 {% set cuda_enabled = cuda_compiler_version is not undefined and cuda_compiler_version == '11.0' %}
 {% set build_ext_version = "1.0.0" %}
 {% set build_ext = "cuda" if cuda_enabled else "cpu" %}
@@ -12,8 +12,8 @@
 {% set install_base = "opt/omnisci" %}
 {% set arrow_version = "6.*" %}
 {% set arrow_proc_version = "3.*" %}
-{% set pythrift_version = "0.15.*" %}
-{% set thrift_version = "0.15.*" %}
+{% set pythrift_version = "0.16.*" %}
+{% set thrift_version = "0.16.*" %}
 # omniscidb 5.10 is not LLVM 12 ready
 {% set llvm_version = "11" %}
 


### PR DESCRIPTION
0.16.0 allows to use thrift on Python 3.10.

See https://github.com/apache/thrift/pull/2487 and https://gitlab.gnome.org/GNOME/libxml2/-/issues/203

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
